### PR TITLE
Update fleshbag_marauder.txt

### DIFF
--- a/forge-gui/res/cardsfolder/f/fleshbag_marauder.txt
+++ b/forge-gui/res/cardsfolder/f/fleshbag_marauder.txt
@@ -4,5 +4,5 @@ Types:Creature Zombie Warrior
 PT:3/1
 T:Mode$ ChangesZone | Origin$ Any | Destination$ Battlefield | ValidCard$ Card.Self | Execute$ TrigSac | TriggerDescription$ When CARDNAME enters the battlefield, each player sacrifices a creature.
 SVar:TrigSac:DB$ Sacrifice | Defined$ Player | SacValid$ Creature
-SVar:NeedsToPlay:Creature.YouDontCtrl
+SVar:NeedsToPlay:Creature.OppCtrl
 Oracle:When Fleshbag Marauder enters the battlefield, each player sacrifices a creature.


### PR DESCRIPTION
Fleshbag Marauder should be played if an OPPONENT has a creature, not just any other player.