### PR TITLE
Added Toy creature type

### DIFF
--- a/forge-gui/res/lists/TypeLists.txt
+++ b/forge-gui/res/lists/TypeLists.txt
@@ -287,6 +287,7 @@ Thopter:Thopters
 Thrull:Thrulls
 Tiefling:Tieflings
 Time Lord:Time Lords
+Toy:Toys
 Treefolk:Treefolks
 Trilobite:Trilobites
 Triskelavite:Triskelavites


### PR DESCRIPTION
I reasoned that artifact types are always before creature types on artifact creatures, so since "Toy" follows "Spider", it must be a creature type.